### PR TITLE
Added payment intent hooks

### DIFF
--- a/lib/modules/webhooks/controllers/stripe-webhooks.controller.ts
+++ b/lib/modules/webhooks/controllers/stripe-webhooks.controller.ts
@@ -22,4 +22,18 @@ export class StripeWebhooksController {
     public async onInvoicePaymentFailure(@Body(new StripeEventPipe<Stripe.Invoice>()) invoice: Stripe.Invoice): Promise<void> {
         return this.service?.invoicePaymentFailure(invoice);
     }
+
+    @Post("payment-intent/success")
+    @ValidateStripeEvent()
+    @HttpCode(HttpStatus.NO_CONTENT)
+    public async onPaymentIntentSuccess(@Body(new StripeEventPipe<Stripe.PaymentIntent>()) intent: Stripe.PaymentIntent): Promise<void> {
+        return this.service?.paymentIntentSuccess(intent);
+    }
+
+    @Post("payment-intent/failure")
+    @ValidateStripeEvent()
+    @HttpCode(HttpStatus.NO_CONTENT)
+    public async onPaymentIntentFailure(@Body(new StripeEventPipe<Stripe.PaymentIntent>()) intent: Stripe.PaymentIntent): Promise<void> {
+        return this.service?.paymentIntentFailure(intent);
+    }
 }

--- a/lib/modules/webhooks/controllers/stripe-webhooks.controller.ts
+++ b/lib/modules/webhooks/controllers/stripe-webhooks.controller.ts
@@ -26,14 +26,18 @@ export class StripeWebhooksController {
     @Post("payment-intent/success")
     @ValidateStripeEvent()
     @HttpCode(HttpStatus.NO_CONTENT)
-    public async onPaymentIntentSuccess(@Body(new StripeEventPipe<Stripe.PaymentIntent>()) intent: Stripe.PaymentIntent): Promise<void> {
+    public async onPaymentIntentSuccess(
+        @Body(new StripeEventPipe<Stripe.PaymentIntent>()) intent: Stripe.PaymentIntent
+    ): Promise<void> {
         return this.service?.paymentIntentSuccess(intent);
     }
 
     @Post("payment-intent/failure")
     @ValidateStripeEvent()
     @HttpCode(HttpStatus.NO_CONTENT)
-    public async onPaymentIntentFailure(@Body(new StripeEventPipe<Stripe.PaymentIntent>()) intent: Stripe.PaymentIntent): Promise<void> {
+    public async onPaymentIntentFailure(
+        @Body(new StripeEventPipe<Stripe.PaymentIntent>()) intent: Stripe.PaymentIntent
+    ): Promise<void> {
         return this.service?.paymentIntentFailure(intent);
     }
 }

--- a/lib/modules/webhooks/services/stripe-webhook-handler.service.ts
+++ b/lib/modules/webhooks/services/stripe-webhook-handler.service.ts
@@ -5,4 +5,6 @@ import { Stripe } from "stripe";
 export abstract class StripeWebhookHandlerService {
     public abstract invoicePaymentSuccess(event: Stripe.Invoice): Promise<void>;
     public abstract invoicePaymentFailure(event: Stripe.Invoice): Promise<void>;
+    public abstract paymentIntentSuccess(event: Stripe.PaymentIntent): Promise<void>;
+    public abstract paymentIntentFailure(event: Stripe.PaymentIntent): Promise<void>;
 }


### PR DESCRIPTION
Ajout de hooks (success & failure) utiles pour recevoir les événements de type Stripe.PaymentIntent.
Ceux-ci contiennent de l'information pertinente sur l'acheteur, son mode de paiement et les éléments intéressants à retrouver sur une facture.
https://stripe.com/docs/payments/payment-intents