### PR TITLE
new tax rates module

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -12,3 +12,4 @@ export * from "./modules/payment-intents";
 export * from "./modules/webhooks";
 export * from "./modules/setup-intents";
 export * from "./modules/subscription-items";
+export * from "./modules/tax-rates";

--- a/lib/modules/tax-rates/index.ts
+++ b/lib/modules/tax-rates/index.ts
@@ -1,0 +1,2 @@
+export * from "./tax-rates.module";
+export * from "./services/tax-rates.service";

--- a/lib/modules/tax-rates/services/tax-rates.service.ts
+++ b/lib/modules/tax-rates/services/tax-rates.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from "@nestjs/common";
+import { Stripe } from "stripe";
+import { InjectStripe } from "../../../decorators/inject-stripe";
+
+@Injectable()
+export class StripeTaxRatesService {
+    constructor(@InjectStripe() private readonly stripe: Stripe) {}
+
+    public create(
+        dto: Stripe.TaxRateCreateParams
+    ): Promise<Stripe.Response<Stripe.TaxRate>> {
+        return this.stripe.taxRates.create(dto);
+    }
+
+    public update(
+        id: string,
+        dto: Stripe.TaxRateUpdateParams
+    ): Promise<Stripe.Response<Stripe.TaxRate>> {
+        return this.stripe.taxRates.update(id, dto);
+    }
+
+    public retrieve(id: string): Promise<Stripe.Response<Stripe.TaxRate>> {
+        return this.stripe.taxRates.retrieve(id);
+    }
+
+    public list(
+        dto: Stripe.TaxRateListParams
+    ): Stripe.ApiListPromise<Stripe.TaxRate> {
+        return this.stripe.taxRates.list(dto);
+    }
+}

--- a/lib/modules/tax-rates/tax-rates.module.ts
+++ b/lib/modules/tax-rates/tax-rates.module.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+import { StripeTaxRatesService } from "./services/tax-rates.service";
+
+@Module({
+    providers: [StripeTaxRatesService],
+    exports: [StripeTaxRatesService]
+})
+export class StripeTaxRatesModule {}


### PR DESCRIPTION
This PR adds a new module `StripeTaxRates` for tax rates management.
https://docs.stripe.com/api/tax_rates/object

### Tax Rate

- Create
- Update
- Retrieve
- List